### PR TITLE
[PUL-419] Fix ambiguous union type check.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8435,6 +8435,11 @@
       "resolved": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
       "integrity": "sha1-h79AKSuM+D5OjOGjrkIJ4gBxZ1o="
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -8450,7 +8455,8 @@
     "lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+      "dev": true
     },
     "lodash.keys": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "avsc": "^5.1.1",
     "debug": "^3.1.0",
     "lodash.flow": "^3.5.0",
-    "lodash.isequal": "^4.5.0",
+    "lodash.includes": "^4.3.0",
     "node-rdkafka": "^2.2.1",
     "request": "^2.83.0",
     "request-promise-native": "^1.0.5",

--- a/src/lib/createAmbiguousUnionTypeHook.js
+++ b/src/lib/createAmbiguousUnionTypeHook.js
@@ -1,6 +1,6 @@
 import avro from 'avsc';
 import utils from 'util';
-import isEqual from 'lodash.isequal';
+import _ from 'lodash';
 import debug from 'debug';
 
 const log = debug('iris:createAmbiguousUnionTypeHook');
@@ -40,10 +40,8 @@ AmbiguousUnionType.prototype._fromValue = function fromValue(val) {
 export default function createAmbiguousUnionTypeHook() {
   const checked = [];
 
-  const beenChecked = attrs =>
-    checked.length > 0 && checked.every(checkedAttrs => isEqual(checkedAttrs, attrs));
+  const beenChecked = attrs => checked.length > 0 && _.includes(checked, attrs);
 
-  // eslint-disable-next-line consistent-return
   return (attrs, opts) => {
     // Let this fall through so that the default type is used
     if (Array.isArray(attrs) && !beenChecked(attrs)) {

--- a/src/lib/createAmbiguousUnionTypeHook.js
+++ b/src/lib/createAmbiguousUnionTypeHook.js
@@ -1,6 +1,6 @@
 import avro from 'avsc';
 import utils from 'util';
-import _ from 'lodash';
+import includes from 'lodash.includes';
 import debug from 'debug';
 
 const log = debug('iris:createAmbiguousUnionTypeHook');
@@ -40,8 +40,9 @@ AmbiguousUnionType.prototype._fromValue = function fromValue(val) {
 export default function createAmbiguousUnionTypeHook() {
   const checked = [];
 
-  const beenChecked = attrs => checked.length > 0 && _.includes(checked, attrs);
+  const beenChecked = attrs => checked.length > 0 && includes(checked, attrs);
 
+  // eslint-disable-next-line consistent-return
   return (attrs, opts) => {
     // Let this fall through so that the default type is used
     if (Array.isArray(attrs) && !beenChecked(attrs)) {

--- a/src/lib/createAmbiguousUnionTypeHook.test.js
+++ b/src/lib/createAmbiguousUnionTypeHook.test.js
@@ -53,7 +53,8 @@ test('Should throw if no potential union types match', () => {
 
   const message = {
     name: 'test name',
-    nullOptional: 123.1
+    nullOptional: 123.1,
+    nullOptionalTwo: 1511902897066
   };
 
   expect(() => avroType.toBuffer(message)).toThrow();
@@ -74,6 +75,16 @@ test('Should decode ambiguous unions by using first match', () => {
           name: 'nullOptional',
           type: ['null', 'float'],
           default: null
+        },
+        {
+          name: 'nullOptionalTwo',
+          type: ['null', 'long'],
+          default: null
+        },
+        {
+          name: 'nullOptionalThree',
+          type: ['null', 'long'],
+          default: null
         }
       ]
     },
@@ -82,13 +93,19 @@ test('Should decode ambiguous unions by using first match', () => {
 
   const message = {
     name: 'test name',
-    nullOptional: 123.1
+    nullOptional: 123.1,
+    nullOptionalTwo: 1511902897066,
+    nullOptionalThree: 1511902897066
   };
 
   const buffer = avroType.toBuffer(message);
-  const { name, nullOptional } = avroType.fromBuffer(buffer);
+  const {
+    name, nullOptional, nullOptionalTwo, nullOptionalThree
+  } = avroType.fromBuffer(buffer);
 
   expect(name).toBe(message.name);
   // Floating points!
   expect(nullOptional).toBeCloseTo(message.nullOptional);
+  expect(nullOptionalTwo).toEqual(message.nullOptionalTwo);
+  expect(nullOptionalThree).toEqual(message.nullOptionalThree);
 });


### PR DESCRIPTION
Error:


```
{"level":50,"time":1511898305617,"msg":"Maximum call stack size exceeded","pid":62,"hostname":"3b46340c9a10","type":"Error","stack":"RangeError: Maximum call stack size exceeded\n    at assocIndexOf (/home/app/node_modules/lodash.isequal/index.js:861:22)\n    at ListCache.listCacheGet [as get] (/home/app/node_modules/lodash.isequal/index.js:519:15)\n    at Stack.stackGet [as get] (/home/app/node_modules/lodash.isequal/index.js:769:24)\n    at equalArrays (/home/app/node_modules/lodash.isequal/index.js:1067:23)\n    at baseIsEqualDeep (/home/app/node_modules/lodash.isequal/index.js:975:9)\n    at baseIsEqual (/home/app/node_modules/lodash.isequal/index.js:935:10)\n    at isEqual (/home/app/node_modules/lodash.isequal/index.js:1639:10)\n    at checked.length.checked.every.checkedAttrs (/home/app/node_modules/@parkhub/iris/src/lib/createAmbiguousUnionTypeHook.js:44:57)\n    at Array.every (<anonymous>)\n    at beenChecked (/home/app/node_modules/@parkhub/iris/src/lib/createAmbiguousUnionTypeHook.js:44:35)","v":1}
```

Schema File:


```
{
    type: "record",
    name: "VendorDeployments",
    namespace: "parkhub.vendor.deployment",
    doc: "Vendor Deployments Schema",
    fields: [
      {
        name: "deploymentId",
        type: "string"
      },
      {
        name: "vendorId",
        type: "string"
      },
      {
        name: "type",
        type: "string"
      },
      {
        name: "topicAction",
        type: "string"
      },
      {
        name: "collectorId",
        type: ["null", "string"],
        default: null
      },
      {
        name: "relayId",
        type: ["null", "string"],
        default: null
      },
      {
        name: "emitterId",
        type: ["null", "string"],
        default: null
      },
      {
        name: "created",
        type: ["null", "long"],
        default: null,
        logicalType: "timestamp-millis"
      },
      {
        name: "updated",
        type: ["null", "long"],
        default: null,
        logicalType: "timestamp-millis"
      }
    ]
  }
```



