### PR TITLE
display error paths PRIM-1673

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,16 +251,16 @@ To run the unit test simply make sure to install the packages locally by running
 `npm start test`
 
 ### Creating a Commit
-We use [semantic-release](https://github.com/semantic-release/semantic-release) to manage our releases.  If you havent worked with it before please take a look at their project to understand more about how it works.
+We use [semantic-release](https://github.com/semantic-release/semantic-release) to manage our releases.  If you haven\'t worked with it before please take a look at their project to understand more about how it works.
 
-1. First I like to run the validate command before running through the commit process because if it fails on validation when your commiting then you will have to go through the commit process again.  To run the validate command simply run this:
+1. First I like to run the validate command before running through the commit process because if it fails on validation when your committing then you will have to go through the commit process again.  To run the validate command simply run this:
 
     `npm start validate`
 
-2. To start a new release make sure you have added your files to git and then run this command:
+2. To start a new release, make sure you have added your files to git and then run this command:
 
     `npm start commit`
 
     This will take you through the release process.  Follow the directions and read the steps throughly.  
 
-3. After you have commited your code and it passes the linter then you can push your branch up to github and create a pull request.
+3. After you have committed your code and it passes the linter then you can push your branch up to Github and create a pull request.

--- a/__tests__/producer.integration.test.js
+++ b/__tests__/producer.integration.test.js
@@ -3,10 +3,10 @@ import schemaRegistry from "../src/lib/schemaRegistry";
 import createSchema from "./fixtures/scripts/createSchema";
 import waitForServicesToBeAvailable from "./fixtures/scripts/waitForServicesToBeAvailable";
 
-const testTopic = "ProducerIntegrationTest";
-const nullTestTopic = "ProducerNullDefaultIntegrationTest";
-const registryUrl = "http://schema-registry:8081";
-const brokerList = "kafka:9092";
+const testTopic = 'ProducerIntegrationTest';
+const nullTestTopic = 'ProducerNullDefaultIntegrationTest';
+const registryUrl = 'http://schema-registry:8081';
+const brokerList = 'kafka:9092';
 
 let registry;
 
@@ -162,8 +162,8 @@ describe("Tests while producer is connected", () => {
 
   test("Should throw if the message does not match the avro schema", () => {
     const message = {
-      age: "25",
       name: 1681,
+      age: "25",
       time: Date.now()
     };
     expect(() => kafkaProducer.produce(testTopic, null, message)).toThrow();

--- a/__tests__/producer.integration.test.js
+++ b/__tests__/producer.integration.test.js
@@ -1,12 +1,12 @@
-import producer from '../src/lib/producer';
-import schemaRegistry from '../src/lib/schemaRegistry';
-import createSchema from './fixtures/scripts/createSchema';
-import waitForServicesToBeAvailable from './fixtures/scripts/waitForServicesToBeAvailable';
+import producer from "../src/lib/producer";
+import schemaRegistry from "../src/lib/schemaRegistry";
+import createSchema from "./fixtures/scripts/createSchema";
+import waitForServicesToBeAvailable from "./fixtures/scripts/waitForServicesToBeAvailable";
 
-const testTopic = 'ProducerIntegrationTest';
-const nullTestTopic = 'ProducerNullDefaultIntegrationTest';
-const registryUrl = 'http://schema-registry:8081';
-const brokerList = 'kafka:9092';
+const testTopic = "ProducerIntegrationTest";
+const nullTestTopic = "ProducerNullDefaultIntegrationTest";
+const registryUrl = "http://schema-registry:8081";
+const brokerList = "kafka:9092";
 
 let registry;
 
@@ -29,7 +29,7 @@ beforeAll(async () => {
   registry = await schemaRegistry({ schemaCfgs, registryUrl });
 });
 
-describe('Tests for producer connectivity', () => {
+describe("Tests for producer connectivity", () => {
   let kafkaProducer;
 
   beforeEach(async () => {
@@ -37,13 +37,13 @@ describe('Tests for producer connectivity', () => {
       producerCfgs: {
         brokerList,
         dr_cb: true,
-        debug: 'all'
+        debug: "all"
       },
       registry
     });
   });
 
-  test('Should connect/disconnect using the promise interface', async () => {
+  test("Should connect/disconnect using the promise interface", async () => {
     const result = await kafkaProducer.connect();
 
     expect(result.orig_broker_id).toBeDefined();
@@ -55,7 +55,7 @@ describe('Tests for producer connectivity', () => {
     await expect(kafkaProducer.getMetadata()).rejects.toBeDefined();
   });
 
-  test('Should connect/disconnect using the callback interface', (done) => {
+  test("Should connect/disconnect using the callback interface", done => {
     kafkaProducer.connect({}, (err, result) => {
       expect(err).toBeNull();
       expect(result.orig_broker_id).toBeDefined();
@@ -71,7 +71,7 @@ describe('Tests for producer connectivity', () => {
   });
 });
 
-describe('Tests while producer is connected', () => {
+describe("Tests while producer is connected", () => {
   let kafkaProducer;
 
   beforeEach(async () => {
@@ -79,7 +79,7 @@ describe('Tests while producer is connected', () => {
       producerCfgs: {
         brokerList,
         dr_cb: true,
-        debug: 'all'
+        debug: "all"
       },
       registry
     });
@@ -91,7 +91,7 @@ describe('Tests while producer is connected', () => {
     await kafkaProducer.disconnect();
   });
 
-  test('Should fetch metadata(which ensures its connected)', async () => {
+  test("Should fetch metadata(which ensures its connected)", async () => {
     const meta = await kafkaProducer.getMetadata();
 
     expect(meta.orig_broker_id).toBeDefined();
@@ -99,7 +99,7 @@ describe('Tests while producer is connected', () => {
     expect(Array.isArray(meta.topics)).toBe(true);
   });
 
-  test('Should fetch metadata(which ensures its connected) using callback', (done) => {
+  test("Should fetch metadata(which ensures its connected) using callback", done => {
     kafkaProducer.getMetadata({}, (err, meta) => {
       expect(err).toBeNull();
 
@@ -111,9 +111,9 @@ describe('Tests while producer is connected', () => {
     });
   });
 
-  test('Should produce a valid avro message', (done) => {
+  test("Should produce a valid avro message", done => {
     const message = {
-      name: 'Bruce Wayne',
+      name: "Bruce Wayne",
       age: 25,
       time: Date.now()
     };
@@ -122,13 +122,13 @@ describe('Tests while producer is connected', () => {
       kafkaProducer.poll();
     }, 500);
 
-    kafkaProducer.once('delivery-report', (err, report) => {
+    kafkaProducer.once("delivery-report", (err, report) => {
       clearInterval(interval);
 
       expect(err).toBeNull();
       expect(report.topic).toBe(testTopic);
-      expect(typeof report.partition).toBe('number');
-      expect(typeof report.offset).toBe('number');
+      expect(typeof report.partition).toBe("number");
+      expect(typeof report.offset).toBe("number");
 
       done();
     });
@@ -136,9 +136,9 @@ describe('Tests while producer is connected', () => {
     kafkaProducer.produce(testTopic, null, message);
   });
 
-  test('Should produce a valid avro message with default null types', (done) => {
+  test("Should produce a valid avro message with default null types", done => {
     const message = {
-      name: 'Bruce Wayne',
+      name: "Bruce Wayne",
       nullValue: 12345
     };
 
@@ -146,13 +146,13 @@ describe('Tests while producer is connected', () => {
       kafkaProducer.poll();
     }, 500);
 
-    kafkaProducer.once('delivery-report', (err, report) => {
+    kafkaProducer.once("delivery-report", (err, report) => {
       clearInterval(interval);
 
       expect(err).toBeNull();
       expect(report.topic).toBe(nullTestTopic);
-      expect(typeof report.partition).toBe('number');
-      expect(typeof report.offset).toBe('number');
+      expect(typeof report.partition).toBe("number");
+      expect(typeof report.offset).toBe("number");
 
       done();
     });
@@ -160,15 +160,14 @@ describe('Tests while producer is connected', () => {
     kafkaProducer.produce(nullTestTopic, null, message);
   });
 
-  test('Should throw if the message does not match the avro schema', () => {
+  test("Should throw if the message does not match the avro schema", () => {
     const message = {
-      name: 'Bruce Wayne',
-      age: '25',
+      name: 1681,
+      age: "25",
       time: Date.now()
     };
-
     expect(() => kafkaProducer.produce(testTopic, null, message)).toThrow();
   });
 
-  test.skip('Should use the promise method of queryWatermarkOffsets', async () => {});
+  test.skip("Should use the promise method of queryWatermarkOffsets", async () => {});
 });

--- a/__tests__/producer.integration.test.js
+++ b/__tests__/producer.integration.test.js
@@ -1,7 +1,7 @@
-import producer from "../src/lib/producer";
-import schemaRegistry from "../src/lib/schemaRegistry";
-import createSchema from "./fixtures/scripts/createSchema";
-import waitForServicesToBeAvailable from "./fixtures/scripts/waitForServicesToBeAvailable";
+import producer from '../src/lib/producer';
+import schemaRegistry from '../src/lib/schemaRegistry';
+import createSchema from './fixtures/scripts/createSchema';
+import waitForServicesToBeAvailable from './fixtures/scripts/waitForServicesToBeAvailable';
 
 const testTopic = 'ProducerIntegrationTest';
 const nullTestTopic = 'ProducerNullDefaultIntegrationTest';
@@ -29,7 +29,7 @@ beforeAll(async () => {
   registry = await schemaRegistry({ schemaCfgs, registryUrl });
 });
 
-describe("Tests for producer connectivity", () => {
+describe('Tests for producer connectivity', () => {
   let kafkaProducer;
 
   beforeEach(async () => {
@@ -37,13 +37,13 @@ describe("Tests for producer connectivity", () => {
       producerCfgs: {
         brokerList,
         dr_cb: true,
-        debug: "all"
+        debug: 'all'
       },
       registry
     });
   });
 
-  test("Should connect/disconnect using the promise interface", async () => {
+  test('Should connect/disconnect using the promise interface', async () => {
     const result = await kafkaProducer.connect();
 
     expect(result.orig_broker_id).toBeDefined();
@@ -55,7 +55,7 @@ describe("Tests for producer connectivity", () => {
     await expect(kafkaProducer.getMetadata()).rejects.toBeDefined();
   });
 
-  test("Should connect/disconnect using the callback interface", done => {
+  test('Should connect/disconnect using the callback interface', (done) => {
     kafkaProducer.connect({}, (err, result) => {
       expect(err).toBeNull();
       expect(result.orig_broker_id).toBeDefined();
@@ -71,7 +71,7 @@ describe("Tests for producer connectivity", () => {
   });
 });
 
-describe("Tests while producer is connected", () => {
+describe('Tests while producer is connected', () => {
   let kafkaProducer;
 
   beforeEach(async () => {
@@ -79,7 +79,7 @@ describe("Tests while producer is connected", () => {
       producerCfgs: {
         brokerList,
         dr_cb: true,
-        debug: "all"
+        debug: 'all'
       },
       registry
     });
@@ -91,7 +91,7 @@ describe("Tests while producer is connected", () => {
     await kafkaProducer.disconnect();
   });
 
-  test("Should fetch metadata(which ensures its connected)", async () => {
+  test('Should fetch metadata(which ensures its connected)', async () => {
     const meta = await kafkaProducer.getMetadata();
 
     expect(meta.orig_broker_id).toBeDefined();
@@ -99,7 +99,7 @@ describe("Tests while producer is connected", () => {
     expect(Array.isArray(meta.topics)).toBe(true);
   });
 
-  test("Should fetch metadata(which ensures its connected) using callback", done => {
+  test('Should fetch metadata(which ensures its connected) using callback', (done) => {
     kafkaProducer.getMetadata({}, (err, meta) => {
       expect(err).toBeNull();
 
@@ -111,9 +111,9 @@ describe("Tests while producer is connected", () => {
     });
   });
 
-  test("Should produce a valid avro message", done => {
+  test('Should produce a valid avro message', (done) => {
     const message = {
-      name: "Bruce Wayne",
+      name: 'Bruce Wayne',
       age: 25,
       time: Date.now()
     };
@@ -122,13 +122,13 @@ describe("Tests while producer is connected", () => {
       kafkaProducer.poll();
     }, 500);
 
-    kafkaProducer.once("delivery-report", (err, report) => {
+    kafkaProducer.once('delivery-report', (err, report) => {
       clearInterval(interval);
 
       expect(err).toBeNull();
       expect(report.topic).toBe(testTopic);
-      expect(typeof report.partition).toBe("number");
-      expect(typeof report.offset).toBe("number");
+      expect(typeof report.partition).toBe('number');
+      expect(typeof report.offset).toBe('number');
 
       done();
     });
@@ -136,9 +136,9 @@ describe("Tests while producer is connected", () => {
     kafkaProducer.produce(testTopic, null, message);
   });
 
-  test("Should produce a valid avro message with default null types", done => {
+  test('Should produce a valid avro message with default null types', (done) => {
     const message = {
-      name: "Bruce Wayne",
+      name: 'Bruce Wayne',
       nullValue: 12345
     };
 
@@ -146,13 +146,13 @@ describe("Tests while producer is connected", () => {
       kafkaProducer.poll();
     }, 500);
 
-    kafkaProducer.once("delivery-report", (err, report) => {
+    kafkaProducer.once('delivery-report', (err, report) => {
       clearInterval(interval);
 
       expect(err).toBeNull();
       expect(report.topic).toBe(nullTestTopic);
-      expect(typeof report.partition).toBe("number");
-      expect(typeof report.offset).toBe("number");
+      expect(typeof report.partition).toBe('number');
+      expect(typeof report.offset).toBe('number');
 
       done();
     });
@@ -160,14 +160,14 @@ describe("Tests while producer is connected", () => {
     kafkaProducer.produce(nullTestTopic, null, message);
   });
 
-  test("Should throw if the message does not match the avro schema", () => {
+  test('Should throw if the message does not match the avro schema', () => {
     const message = {
       name: 1681,
-      age: "25",
+      age: '25',
       time: Date.now()
     };
     expect(() => kafkaProducer.produce(testTopic, null, message)).toThrow();
   });
 
-  test.skip("Should use the promise method of queryWatermarkOffsets", async () => {});
+  test.skip('Should use the promise method of queryWatermarkOffsets', async () => {});
 });

--- a/__tests__/producer.integration.test.js
+++ b/__tests__/producer.integration.test.js
@@ -162,8 +162,8 @@ describe("Tests while producer is connected", () => {
 
   test("Should throw if the message does not match the avro schema", () => {
     const message = {
-      name: 1681,
       age: "25",
+      name: 1681,
       time: Date.now()
     };
     expect(() => kafkaProducer.produce(testTopic, null, message)).toThrow();

--- a/src/lib/createIrisConsumer.js
+++ b/src/lib/createIrisConsumer.js
@@ -24,7 +24,6 @@ export default function createIrisConsumer(registry) {
 
           resolve(offsets);
         }));
-
     return client;
   };
 }

--- a/src/lib/createIrisProducer.js
+++ b/src/lib/createIrisProducer.js
@@ -3,7 +3,7 @@ import serializeMessageToSchemaRegistryAvro from './serializeMessageToSchemaRegi
 
 const log = debug('iris:producer:createIrisProducer');
 
-export default function createIrisProducer(registry) {
+export default function createIrisProducer(registry) { //overwriting rdkafka
   return (client) => {
     const clientProduce = client.produce.bind(client);
 

--- a/src/lib/createIrisProducer.js
+++ b/src/lib/createIrisProducer.js
@@ -3,7 +3,7 @@ import serializeMessageToSchemaRegistryAvro from './serializeMessageToSchemaRegi
 
 const log = debug('iris:producer:createIrisProducer');
 
-export default function createIrisProducer(registry) { //overwriting rdkafka
+export default function createIrisProducer(registry) { // overwriting rdkafka
   return (client) => {
     const clientProduce = client.produce.bind(client);
 

--- a/src/lib/producer.js
+++ b/src/lib/producer.js
@@ -8,9 +8,9 @@ export default function producer(cfgs) {
 
   const irisFactory = createIrisProducer(registry);
 
-  //flow passes producerCfgs as params into createRDKProducer,
-  //then the result of that into promisifyCommonMethods,
-  //thenthe result of that into irisFactor,
-  //then returns the result of that.
+  // flow passes producerCfgs as params into createRDKProducer,
+  // then the result of that into promisifyCommonMethods,
+  // thenthe result of that into irisFactor,
+  // then returns the result of that.
   return flow(createRDKProducer, promisifyCommonMethods, irisFactory)(producerCfgs);
 }

--- a/src/lib/producer.js
+++ b/src/lib/producer.js
@@ -8,5 +8,9 @@ export default function producer(cfgs) {
 
   const irisFactory = createIrisProducer(registry);
 
+  //flow passes producerCfgs as params into createRDKProducer,
+  //then the result of that into promisifyCommonMethods,
+  //thenthe result of that into irisFactor,
+  //then returns the result of that.
   return flow(createRDKProducer, promisifyCommonMethods, irisFactory)(producerCfgs);
 }

--- a/src/lib/serializeMessageToSchemaRegistryAvro.js
+++ b/src/lib/serializeMessageToSchemaRegistryAvro.js
@@ -26,12 +26,12 @@ export default function serializeMessageToSchemaRegistryAvro(cfgs, startingLengt
         paths.push(path.join());
       }
     });
-    log(
-      'There has been an error in encoding your message. \nCheck your Schema.\nInvalid schema paths: ',
-      paths,
-      err.message
-    );
-    throw err;
+    const validationError = {};
+    validationError.type = 'VALIDATION_ERROR';
+    validationError.message = 'There has been an error in encoding your message. \nCheck your Schema.\nInvalid schema paths: ';
+    validationError.invalidKeys = paths;
+    log(validationError);
+    throw validationError;
   }
 
   if (pos < 0) {

--- a/src/lib/serializeMessageToSchemaRegistryAvro.js
+++ b/src/lib/serializeMessageToSchemaRegistryAvro.js
@@ -28,7 +28,8 @@ export default function serializeMessageToSchemaRegistryAvro(cfgs, startingLengt
     });
     log(
       'There has been an error in encoding your message. \nCheck your Schema.\nInvalid schema paths: ',
-      paths
+      paths,
+      err.message
     );
     throw err;
   }

--- a/src/lib/serializeMessageToSchemaRegistryAvro.js
+++ b/src/lib/serializeMessageToSchemaRegistryAvro.js
@@ -1,16 +1,36 @@
 const magicByte = 0;
 
-export default function serializeMessageToSchemaRegistryAvro(cfgs, startingLength) {
+export default function serializeMessageToSchemaRegistryAvro(
+  cfgs,
+  startingLength
+) {
   const { message, registry, topic } = cfgs;
   const { schemaType, schemaId } = registry.getSchemaInfoByTopic({ topic });
 
   const length = startingLength || 1024;
   const buf = Buffer.alloc(length);
 
+  let pos;
+
   buf[0] = magicByte; // Magic byte.
   buf.writeInt32BE(schemaId, 1);
 
-  const pos = schemaType.encode(message, buf, 5);
+  try {
+    pos = schemaType.encode(message, buf, 5); //encode message into avro
+  } catch (err) {
+    console.log(
+      "There has been an error in encoding your message. \nCheck your Schema."
+    );
+    let paths = [];
+    schemaType.isValid(message, {
+      //Check message against schema
+      errorHook: function(path) {
+        //Track paths that cause issues
+        paths.push(path.join());
+      }
+    });
+    console.log("Invalid schema paths: " + paths);
+  }
 
   if (pos < 0) {
     // The buffer was too short, we need to resize.

--- a/src/lib/serializeMessageToSchemaRegistryAvro.test.js
+++ b/src/lib/serializeMessageToSchemaRegistryAvro.test.js
@@ -75,3 +75,20 @@ test('Should serialize a big message to schema registry valid avro', () => {
   expect(schemaId).toBe(1);
   expect(decodedMessage).toEqual(message);
 });
+
+test('Should throw in attempt to serialize invalid message to schema registry avro', () => {
+  const registry = registryFixture();
+  // const avroType = schemaFixture();
+
+  const message = {
+    name: 55,
+    int: 'notAnInt' // error here as it should be an int.
+  };
+
+  expect(() =>
+    serializeMessageToSchemaRegistryAvro({
+      message,
+      registry,
+      topic: 'test'
+    })).toThrow();
+});


### PR DESCRIPTION
Added a block in `serializeMessageToSchemaRegistryAvro.js` that lists the paths where errors are found when comparing the message to the schema.  Used the `isValid` function with an error hook.

https://gist.github.com/mtth/fe006b5b001beeaed95f#file-collect-js

PRIM-1673
